### PR TITLE
the files array had the wrong name for main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,5 @@
   "devDependencies": {
     "seneca": "~0.5.17",
     "mocha": "~1.18.2"
-  },
-  "files": [
-    "LICENSE.txt",
-    "README.md",
-    "seneca-jsonfile-store.js"
-  ]
+  }
 }


### PR DESCRIPTION
(jsonfile-store.js) as a result, the file wasn't installing (meaning jsonfile-store doesn't currently install properly via npm install seneca-jsonfile-store)
Removing file array removes danger of this happening again
