### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/db/**/*.json.DELETE
 
 docs/annotated
 docs/coverage.html
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,27 +1,13 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
+> A [Seneca.js][] data storage plugin.
 
-> A [Seneca.js][] data storage plugin
+# @seneca/jsonfile-store
 
-# seneca-jsonfile-store
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Dependency Status][david-badge]][david-url]
-[![Gitter][gitter-badge]][gitter-url]
-
-## Description
-This module is a plugin for [Seneca.js][]. It provides a storage engine that uses JSON files to
-persist data. This module is not appropriate for production usage, it is intended for very low
-workloads, and as a example of a storage plugin code base.
-
-For a gentle introduction to Seneca itself, see the [senecajs.org][seneca.js] site.
-
-### Seneca compatibility
-Supports Seneca versions **1.x** - **3.x**
-
-### Supported functionality
-All Seneca data store supported functionality is implemented in [seneca-store-test](https://github.com/senecajs/seneca-store-test) as a test suite. The tests represent the store functionality specifications.
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
 ## Install
+
 To install, simply use npm. Remember you will need to install [Seneca.js][] separately.
 
 ```sh
@@ -29,22 +15,8 @@ npm install seneca
 npm install seneca-jsonfile-store
 ```
 
-## Usage
-You don't use this module directly. It provides an underlying data storage engine
-for the Seneca entity API:
-
-```js
-var entity = seneca.make$('typename')
-entity.someproperty = "something"
-entity.anotherproperty = 100
-
-entity.save$(function (err, entity) { ... })
-entity.load$({ id: ... }, function (err, entity) { ... })
-entity.list$({ property: ... }, function (err, entity) { ... })
-entity.remove$({ id: ... }, function (err, entity) { ... })
-```
-
 ## Quick Example
+
 ```js
 var seneca = require('seneca')()
 seneca.use('jsonfile-store', {
@@ -77,22 +49,68 @@ The standard Seneca query format is supported:
 
 Note: you can use `sort$`, `limit$`, `skip$` and `fields$` together.
 
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+This module is a plugin for [Seneca.js][]. It provides a storage engine that uses JSON files to persist data. Not appropriate for production usage — intended for low workloads and as an example of a storage plugin.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
+- Ask on the [Gitter][gitter-url]
+
+## API
+
+You don't use this module directly. It provides an underlying data storage engine for the Seneca entity API:
+
+```js
+var entity = seneca.make$('typename')
+entity.someproperty = "something"
+entity.anotherproperty = 100
+
+entity.save$(function (err, entity) { ... })
+entity.load$({id: ... }, function (err, entity) { ... })
+entity.list$({property: ... }, function (err, entity) { ... })
+entity.remove$({id: ... }, function (err, entity) { ... })
+```
+
+
+### Query Support
+
+- `.list$({f1:v1, f2:v2, ...})` implies pseudo-query `f1==v1 AND f2==v2, ...`.
+- `.list$({f1:v1,...}, {sort$:{field1:1}})` means sort by f1, ascending.
+- `.list$({f1:v1,...}, {sort$:{field1:-1}})` means sort by f1, descending.
+- `.list$({f1:v1,...}, {limit$:10})` means only return 10 results.
+- `.list$({f1:v1,...}, {skip$:5})` means skip the first 5.
+- `.list$({f1:v1,...}, {fields$:['fd1','f2']})` means only return the listed fields.
+
 ## Contributing
+
 The [Senecajs org][] encourages open participation. If you feel you
 can help in any way, be it with documentation, examples, extra
 testing, or new features please get in touch.
 
-## Test
-To run tests, simply use npm:
+
+### Running tests
 
 ```sh
 npm run test
 ```
 
-## License
-Copyright (c) 2012-2016, Richard Rodger and other contributors.
-Licensed under [MIT][].
+## Background
 
+This plugin stores data as JSON files on disk.
+
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Dependency Status][david-badge]][david-url]
+[![Gitter][gitter-badge]][gitter-url]
 [MIT]: ./LICENSE
 [Senecajs org]: https://github.com/senecajs/
 [Seneca.js]: https://www.npmjs.com/package/seneca

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-jsonfile-store",
+  "name": "@seneca/jsonfile-store",
   "version": "1.0.1",
   "description": "Seneca data store plugin that uses plain JSON files",
   "main": "jsonfile-store.js",


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`